### PR TITLE
Run WorlSeeder last when running php artisan db:seed

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -17,11 +17,12 @@ final class DatabaseSeeder extends Seeder
         $this->call(ReactionSeeder::class);
         $this->call(ChannelSeeder::class);
         $this->call(DeveloperPremiumPlanSeeder::class);
-        $this->call(WorldSeeder::class);
         $this->call(FeatureTableSeeder::class);
 
         if ( ! App::environment('production')) {
             $this->call(UserSeeder::class);
         }
+
+        $this->call(WorldSeeder::class);
     }
 }


### PR DESCRIPTION
when I run `php artisan db:seed`, all the seeder get called, except `FeatureTableSeeder` & `UserSeeder`

calling Seeder stops after `call(WorldSeeder`, nothing else gets called! (I don'tknow why).

![screenshot](https://user-images.githubusercontent.com/4411670/256941050-38ba00a3-be49-4c43-8cce-326b0e2fa7bb.png)

puhsing `WorldSeeder` to be the last one to call, solve the issue.

this sovles the issue #32